### PR TITLE
fix: Remove deploy check from required PR status checks

### DIFF
--- a/.cursor/rules/pr-review.md
+++ b/.cursor/rules/pr-review.md
@@ -26,3 +26,9 @@ When reviewing a Pull Request, check:
 
 #
 - lways ask before you push to the origin
+
+## Git Workflow
+- **NEVER push directly to main** - Always create a feature branch and PR
+- All changes must go through pull requests, even small fixes
+- Ask before bypassing branch protection rules
+- Use descriptive branch names: `feature/`, `fix/`, `docs/`, `refactor/`


### PR DESCRIPTION
## Problem

The "deploy" check is currently required for pull requests, but the deploy workflow only runs on pushes to `main` branch. This causes PRs to show "Expected — Waiting for status to be reported" and blocks merging.

## Solution

This PR:
- ✅ Adds automated script (`scripts/fix-branch-protection.sh`) to remove deploy from required checks
- ✅ Adds comprehensive documentation (`docs/BRANCH_PROTECTION_FIX.md`)
- ✅ Updates README with branch protection rules section
- ✅ Updates AUTO_DEPLOYMENT.md with troubleshooting info
- ✅ Adds warning comment to deploy workflow

## Changes

- **New script**: `scripts/fix-branch-protection.sh` - Automatically fixes branch protection rules
- **New doc**: `docs/BRANCH_PROTECTION_FIX.md` - Complete guide for fixing the issue
- **Updated**: `README.md` - Added branch protection section and troubleshooting
- **Updated**: `docs/AUTO_DEPLOYMENT.md` - Added note about deploy check
- **Updated**: `.github/workflows/deploy.yml` - Added warning comment

## How to Test

After merging, run:
```bash
./scripts/fix-branch-protection.sh
```

Or manually: Settings → Branches → Branch protection rules → Edit → Uncheck "deploy"

## Related

Fixes the issue where PRs show "Expected — Waiting for status to be reported" for the deploy check.