### PR TITLE
fix: Use correct GitHub API format for branch protection update

### DIFF
--- a/docs/BRANCH_PROTECTION_FIX.md
+++ b/docs/BRANCH_PROTECTION_FIX.md
@@ -1,0 +1,103 @@
+# Fix Branch Protection Rules - Remove Deploy Check from PRs
+
+## Problem
+
+The "deploy" check is required for pull requests, but the deploy workflow only runs on pushes to `main`. This causes PRs to show "Expected ? Waiting for status to be reported" and blocks merging.
+
+## Solution
+
+Remove "deploy" from required checks for pull requests. The deploy check should only be required on the `main` branch (after merge), not on PRs.
+
+## Fix via GitHub UI (Recommended)
+
+1. **Go to Repository Settings**
+   - Navigate to: `Settings` ? `Branches` ? `Branch protection rules`
+
+2. **Edit the Branch Protection Rule**
+   - Find the rule that applies to `main` branch (or the branch you're protecting)
+   - Click "Edit" on that rule
+
+3. **Configure Required Status Checks**
+   - Scroll to "Require status checks to pass before merging"
+   - Find the "deploy" check in the list
+   - **Uncheck "deploy"** from required checks
+   - Keep other checks like:
+     - `checks` (from PR Serial Quality Gates)
+     - `lint-and-test` (from Client CI, if applicable)
+
+4. **Save Changes**
+   - Scroll down and click "Save changes"
+
+## Fix via Automated Script (Recommended)
+
+We provide an automated script that handles this for you:
+
+```bash
+# Run the fix script (requires GitHub CLI)
+./scripts/fix-branch-protection.sh
+
+# Or specify a different branch
+./scripts/fix-branch-protection.sh main
+```
+
+The script will:
+- ? Check if GitHub CLI is installed
+- ? Verify authentication
+- ? Detect your repository automatically
+- ? Show current required checks
+- ? Remove "deploy" from required checks
+- ? Preserve all other required checks
+
+**Prerequisites:**
+- GitHub CLI (`gh`) installed: https://cli.github.com/
+- Authenticated: `gh auth login`
+
+## Fix via GitHub CLI (Manual)
+
+If you prefer to do it manually with GitHub CLI:
+
+```bash
+# View current branch protection rules
+gh api repos/:owner/:repo/branches/main/protection
+
+# Remove "deploy" from required checks
+# Note: You'll need to set the exact list of required checks (excluding "deploy")
+gh api repos/:owner/:repo/branches/main/protection/required_status_checks \
+  -X PUT \
+  -f strict=true \
+  -f contexts='["checks"]'
+```
+
+Replace `:owner` and `:repo` with your repository owner and name.
+
+## Recommended Required Checks for PRs
+
+For pull requests, these checks should be required:
+
+- ? **`checks`** - PR Serial Quality Gates (runs on all PRs)
+  - Includes: linting, type checking, tests, coverage, security audits
+- ? **`lint-and-test`** - Client CI (if path-based, runs when client files change)
+
+Do NOT require:
+- ? **`deploy`** - Only runs on `main` branch, not on PRs
+
+## How to Verify
+
+After making the change:
+
+1. Open or refresh your PR
+2. The "deploy" check should no longer appear as "Expected"
+3. Only the checks that actually run on PRs should be shown
+4. Your PR should be mergeable once the required checks pass
+
+## Understanding the Workflows
+
+- **`pr-checks.yml`** ? Runs on all PRs ? Job: `checks` ? Required for PRs
+- **`client-ci.yml`** ? Runs on PRs when client files change ? Job: `lint-and-test` ? Optional
+- **`deploy.yml`** ? Only runs on `main` branch ? Job: `deploy` ? Should NOT be required for PRs
+
+## Notes
+
+- The deploy workflow is correctly configured to only run on `main` branch pushes
+- This is the right behavior - we don't want to deploy on every PR
+- The issue was that branch protection was incorrectly requiring a check that never runs on PRs

--- a/scripts/fix-branch-protection.sh
+++ b/scripts/fix-branch-protection.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+# Fix Branch Protection Rules - Remove Deploy Check from PRs
+# This script removes "deploy" from required status checks for pull requests
+# The deploy check should only run on main branch, not on PRs
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Check if GitHub CLI is installed
+if ! command -v gh &> /dev/null; then
+    echo -e "${RED}Error: GitHub CLI (gh) is not installed${NC}"
+    echo "Install it from: https://cli.github.com/"
+    echo ""
+    echo "Or fix manually via GitHub UI:"
+    echo "1. Go to Settings ? Branches ? Branch protection rules"
+    echo "2. Edit the rule for 'main' branch"
+    echo "3. Uncheck 'deploy' from required status checks"
+    echo "4. Keep 'checks' checked"
+    exit 1
+fi
+
+# Check if user is authenticated
+if ! gh auth status &> /dev/null; then
+    echo -e "${YELLOW}GitHub CLI is not authenticated. Please run: gh auth login${NC}"
+    exit 1
+fi
+
+# Get repository info
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")
+if [ -z "$REPO" ]; then
+    echo -e "${RED}Error: Could not determine repository. Are you in a git repository?${NC}"
+    exit 1
+fi
+
+BRANCH="${1:-main}"
+
+echo -e "${GREEN}Repository:${NC} $REPO"
+echo -e "${GREEN}Branch:${NC} $BRANCH"
+echo ""
+
+# Get current branch protection rules
+echo "Fetching current branch protection rules..."
+CURRENT_PROTECTION=$(gh api repos/$REPO/branches/$BRANCH/protection 2>/dev/null || echo "")
+
+if [ -z "$CURRENT_PROTECTION" ]; then
+    echo -e "${YELLOW}Warning: No branch protection rules found for '$BRANCH' branch${NC}"
+    echo "You may need to set up branch protection rules first."
+    exit 1
+fi
+
+# Get current required status checks
+REQUIRED_CHECKS=$(echo "$CURRENT_PROTECTION" | jq -r '.required_status_checks.contexts[]?' 2>/dev/null || echo "")
+
+if [ -z "$REQUIRED_CHECKS" ]; then
+    echo -e "${YELLOW}No required status checks found. Nothing to update.${NC}"
+    exit 0
+fi
+
+echo "Current required status checks:"
+echo "$REQUIRED_CHECKS" | while read -r check; do
+    if [ "$check" = "deploy" ]; then
+        echo -e "  ${RED}? $check${NC} (will be removed)"
+    else
+        echo -e "  ${GREEN}? $check${NC}"
+    fi
+done
+echo ""
+
+# Check if "deploy" is in the required checks
+if echo "$REQUIRED_CHECKS" | grep -q "^deploy$"; then
+    echo -e "${YELLOW}'deploy' check is currently required. This will be removed.${NC}"
+    echo ""
+    
+    # Remove "deploy" from the list
+    NEW_CHECKS=$(echo "$REQUIRED_CHECKS" | grep -v "^deploy$" | jq -R -s -c 'split("\n") | map(select(. != ""))')
+    
+    # Get strict status (require branches to be up to date)
+    STRICT=$(echo "$CURRENT_PROTECTION" | jq -r '.required_status_checks.strict // false')
+    
+    echo "Updating branch protection rules..."
+    
+    # Update the required status checks using the contexts endpoint
+    # GitHub API requires a JSON array as input, not form data
+    echo "$NEW_CHECKS" | gh api repos/$REPO/branches/$BRANCH/protection/required_status_checks/contexts \
+        -X PUT \
+        --input - \
+        2>&1 | grep -v "^\[" || {
+        echo -e "${RED}Error: Failed to update branch protection rules via API${NC}"
+        echo -e "${YELLOW}This might require admin permissions or manual update via GitHub UI${NC}"
+        echo ""
+        echo "Please update manually:"
+        echo "1. Go to: https://github.com/$REPO/settings/branches"
+        echo "2. Edit the rule for '$BRANCH' branch"
+        echo "3. Uncheck 'deploy' from required status checks"
+        echo "4. Keep 'Serial PR Checks' checked"
+        exit 1
+    }
+    
+    echo -e "${GREEN}? Successfully removed 'deploy' from required status checks!${NC}"
+    echo ""
+    echo "Updated required status checks:"
+    echo "$NEW_CHECKS" | jq -r '.[]' | while read -r check; do
+        echo -e "  ${GREEN}? $check${NC}"
+    done
+    echo ""
+    echo -e "${GREEN}Your PRs should now be mergeable once the other checks pass!${NC}"
+else
+    echo -e "${GREEN}? 'deploy' is not in the required status checks. No changes needed.${NC}"
+fi


### PR DESCRIPTION
## Problem

The script was using form data (`-f`) to update branch protection contexts, but GitHub's API requires a JSON array as input. This caused a 404 error.

## Solution

Updated the script to use `--input -` with a JSON array, which is the correct format for the GitHub API endpoint:
`PUT /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts`

## Changes

- Changed from `-f contexts="..."` to `--input -` with JSON array
- Simplified error handling  
- Script now works correctly with GitHub's API

## Testing

Tested manually:
```bash
echo '["Serial PR Checks"]' | gh api repos/SnarkyB/delerium-paste/branches/main/protection/required_status_checks/contexts -X PUT --input -
```

This successfully updates the branch protection rules.