### PR TITLE
v0.1.7

### DIFF
--- a/.idea/modules/delerium-paste-server.iml
+++ b/.idea/modules/delerium-paste-server.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="delerium-paste-server" external.linked.project.path="$MODULE_DIR$/../../server" external.root.project.path="$MODULE_DIR$/../../server" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="delerium-paste-server" external.linked.project.path="$MODULE_DIR$/../../server" external.root.project.path="$MODULE_DIR$/../../server" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="0.1.7-alpha" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_21" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../server">

--- a/.idea/modules/delerium-paste-server.main.iml
+++ b/.idea/modules/delerium-paste-server.main.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="delerium-paste-server:main" external.linked.project.path="$MODULE_DIR$/../../server" external.root.project.path="$MODULE_DIR$/../../server" external.system.id="GRADLE" external.system.module.group="" external.system.module.type="sourceSet" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="delerium-paste-server:main" external.linked.project.path="$MODULE_DIR$/../../server" external.root.project.path="$MODULE_DIR$/../../server" external.system.id="GRADLE" external.system.module.group="" external.system.module.type="sourceSet" external.system.module.version="0.1.7-alpha" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet external-system-id="GRADLE" type="kotlin-language" name="Kotlin">
       <configuration version="5" platform="JVM 21" allPlatforms="JVM [21]" useProjectSettings="false" pureKotlinSourceFolders="$MODULE_DIR$/../../server/src/test/kotlin;/Users/marcusb/src/repos/delerium-paste/server/src/main/kotlin">

--- a/.idea/modules/delerium-paste-server.test.iml
+++ b/.idea/modules/delerium-paste-server.test.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="delerium-paste-server:test" external.linked.project.path="$MODULE_DIR$/../../server" external.root.project.path="$MODULE_DIR$/../../server" external.system.id="GRADLE" external.system.module.group="" external.system.module.type="sourceSet" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="delerium-paste-server:test" external.linked.project.path="$MODULE_DIR$/../../server" external.root.project.path="$MODULE_DIR$/../../server" external.system.id="GRADLE" external.system.module.group="" external.system.module.type="sourceSet" external.system.module.version="0.1.7-alpha" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet external-system-id="GRADLE" type="kotlin-language" name="Kotlin">
       <configuration version="5" platform="JVM 21" allPlatforms="JVM [21]" useProjectSettings="false" pureKotlinSourceFolders="$MODULE_DIR$/../../server/src/test/kotlin;/Users/marcusb/src/repos/delerium-paste/server/src/main/kotlin">

--- a/client/delete.html
+++ b/client/delete.html
@@ -57,7 +57,7 @@
     </div>
 
     <!-- Version Display -->
-    <a href="https://github.com/SnarkyB/delerium-paste" target="_blank" rel="noopener noreferrer" class="version-display">v0.1.6-alpha</a>
+    <a href="https://github.com/SnarkyB/delerium-paste" target="_blank" rel="noopener noreferrer" class="version-display">v0.1.7-alpha</a>
     
     <script src="js/delete.js"></script>
   </body>

--- a/client/index.html
+++ b/client/index.html
@@ -717,7 +717,7 @@
     </div>
 
     <!-- Version Display -->
-    <a href="https://github.com/SnarkyB/delerium-paste" target="_blank" rel="noopener noreferrer" class="version-display">v0.1.6-alpha</a>
+    <a href="https://github.com/SnarkyB/delerium-paste" target="_blank" rel="noopener noreferrer" class="version-display">v0.1.7-alpha</a>
 
     <script type="module" src="js/app.js"></script>
   </body>

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkpaste-client",
-  "version": "1.0.0",
+  "version": "0.1.7-alpha",
   "description": "Client-side TypeScript for zkpaste",
   "scripts": {
     "build": "npx tsc",

--- a/client/tests/e2e/delete-paste.spec.js
+++ b/client/tests/e2e/delete-paste.spec.js
@@ -341,7 +341,7 @@ test.describe('Delete Page - UI and UX', () => {
         // Verify version display
         const versionDisplay = page.locator('.version-display');
         await expect(versionDisplay).toBeVisible();
-        await expect(versionDisplay).toContainText('v0.1.6-alpha');
+        await expect(versionDisplay).toContainText('v0.1.7-alpha');
         // Verify it links to GitHub
         await expect(versionDisplay).toHaveAttribute('href', 'https://github.com/SnarkyB/delerium-paste');
     });

--- a/client/tests/e2e/delete-paste.spec.ts
+++ b/client/tests/e2e/delete-paste.spec.ts
@@ -396,7 +396,7 @@ test.describe('Delete Page - UI and UX', () => {
     // Verify version display
     const versionDisplay = page.locator('.version-display');
     await expect(versionDisplay).toBeVisible();
-    await expect(versionDisplay).toContainText('v0.1.6-alpha');
+    await expect(versionDisplay).toContainText('v0.1.7-alpha');
     
     // Verify it links to GitHub
     await expect(versionDisplay).toHaveAttribute('href', 'https://github.com/SnarkyB/delerium-paste');

--- a/client/view.html
+++ b/client/view.html
@@ -409,7 +409,7 @@
     </div>
 
     <!-- Version Display -->
-    <a href="https://github.com/SnarkyB/delerium-paste" target="_blank" rel="noopener noreferrer" class="version-display">v0.1.6-alpha</a>
+    <a href="https://github.com/SnarkyB/delerium-paste" target="_blank" rel="noopener noreferrer" class="version-display">v0.1.7-alpha</a>
 
     <script type="module" src="js/app.js"></script>
   </body>

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -3,6 +3,9 @@ plugins {
     application
     id("org.owasp.dependencycheck") version "11.1.0"
 }
+
+version = "0.1.7-alpha"
+
 repositories { mavenCentral() }
 dependencies {
     val ktor = "3.3.2"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps to v0.1.7-alpha across server Gradle config, client package.json, UI version displays, and updates e2e tests to match.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b73237a15b65c1069de40823e38718b9f5cd779f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->