### PR TITLE
fix: resolve CSP violation in view page 'Create New Paste' button

### DIFF
--- a/client/src/app.ts
+++ b/client/src/app.ts
@@ -21,7 +21,8 @@ import {
   setupViewCopyButton,
   setupUrlInputSelection,
   setupPasswordToggle,
-  setupSingleViewToggle
+  setupSingleViewToggle,
+  setupNewPasteButton
 } from './ui/dom-helpers.js';
 
 import { initializeWindowUI } from './ui/ui-manager.js';
@@ -52,6 +53,7 @@ function initializeApp(): void {
     setupUrlInputSelection();
     setupPasswordToggle();
     setupSingleViewToggle();
+    setupNewPasteButton();
   });
   
   // Setup paste creation (for index.html)

--- a/client/src/ui/dom-helpers.ts
+++ b/client/src/ui/dom-helpers.ts
@@ -138,3 +138,19 @@ export function setupSingleViewToggle(): void {
     });
   }
 }
+
+/**
+ * Setup "Create New Paste" button navigation
+ */
+export function setupNewPasteButton(): void {
+  if (typeof document === 'undefined') return;
+  const newPasteBtn = document.getElementById('newPasteBtn') as HTMLButtonElement | null;
+  if (!newPasteBtn) return;
+
+  newPasteBtn.addEventListener('click', (event) => {
+    event.preventDefault();
+    // Use URL constructor to preserve directory structure in case of subdirectory deployments
+    const targetUrl = new URL('index.html', window.location.href).toString();
+    window.location.assign(targetUrl);
+  });
+}

--- a/client/tests/e2e/paste-flow.spec.ts
+++ b/client/tests/e2e/paste-flow.spec.ts
@@ -168,6 +168,38 @@ test.describe('Paste Creation and Viewing Flow', () => {
 });
 
 test.describe('Paste Viewing Flow', () => {
+  test('should navigate to create page when clicking "Create New Paste" button', async ({ page }) => {
+    // Mock the paste API endpoint
+    await page.route('**/api/pastes/test-paste-id', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ct: 'test-ciphertext',
+          iv: 'test-iv'
+        })
+      });
+    });
+
+    // Navigate to view page with paste ID and key
+    await page.goto('/view.html?p=test-paste-id#test-key:test-iv');
+
+    // Wait for page to load
+    await page.waitForSelector('#newPasteBtn');
+
+    // Verify the button is visible
+    const newPasteBtn = page.locator('#newPasteBtn');
+    await expect(newPasteBtn).toBeVisible();
+    await expect(newPasteBtn).toContainText('Create New Paste');
+
+    // Click the button
+    await newPasteBtn.click();
+
+    // Verify navigation to index.html
+    await page.waitForURL('**/index.html');
+    expect(page.url()).toContain('index.html');
+  });
+
   test('should decrypt and display paste content', async ({ page }) => {
     // Mock the paste API endpoint
     await page.route('**/api/pastes/test-paste-id', async route => {

--- a/client/view.html
+++ b/client/view.html
@@ -369,20 +369,20 @@
       <div class="card">
         <pre id="content" class="loading">Decrypting your secure paste...</pre>
 
-        <div class="actions">
-          <button class="btn btn-primary" id="copyBtn">
-            <span>📋</span>
-            <span id="copyText">Copy to Clipboard</span>
-          </button>
-          <button class="btn btn-secondary" onclick="window.location.href='index.html'">
-            <span>➕</span>
-            <span>Create New Paste</span>
-          </button>
-          <button class="btn btn-danger" id="destroyBtn" style="display: none;">
-            <span>🗑️</span>
-            <span>Destroy Paste</span>
-          </button>
-        </div>
+          <div class="actions">
+            <button class="btn btn-primary" id="copyBtn">
+              <span>📋</span>
+              <span id="copyText">Copy to Clipboard</span>
+            </button>
+            <button class="btn btn-secondary" id="newPasteBtn" type="button">
+              <span>➕</span>
+              <span>Create New Paste</span>
+            </button>
+            <button class="btn btn-danger" id="destroyBtn" style="display: none;">
+              <span>🗑️</span>
+              <span>Destroy Paste</span>
+            </button>
+          </div>
 
         <div class="info-bar" id="infoBar" style="display: none;">
           <div class="info-item">


### PR DESCRIPTION
## Summary

Fixes the non-functional "Create New Paste" button on the paste view page by resolving a Content Security Policy (CSP) violation.

## Problem

The button used an inline `onclick` handler which is blocked by the strict CSP policy (`script-src 'self'`). This prevented users from navigating back to the creation page after viewing a paste.

## Solution

- ✅ Removed inline `onclick` handler from `view.html`
- ✅ Added semantic `id="newPasteBtn"` and `type="button"` attributes
- ✅ Created `setupNewPasteButton()` helper in `dom-helpers.ts` following existing patterns
- ✅ Wired helper into `app.ts` bootstrap alongside other UI setups
- ✅ Added E2E test coverage to prevent regression
- ✅ Used URL constructor for subdirectory-safe navigation

## Changes

- `client/view.html` - Updated button markup (removed inline handler, added id)
- `client/src/ui/dom-helpers.ts` - Added new helper function
- `client/src/app.ts` - Imported and called new helper
- `client/tests/e2e/paste-flow.spec.ts` - Added test for button navigation

## Test Plan

- [x] Unit tests pass (207 tests)
- [x] E2E tests pass including new navigation test
- [x] Pre-commit hooks pass (ESLint, TypeScript, tests)
- [x] Manual verification: button now works correctly
- [x] No CSP violations in browser console

## Files Changed

```
 client/src/app.ts                   |  4 +++-
 client/src/ui/dom-helpers.ts        | 16 ++++++++++++++++
 client/tests/e2e/paste-flow.spec.ts | 32 ++++++++++++++++++++++++++++++++
 client/view.html                    | 28 ++++++++++++++--------------
 4 files changed, 65 insertions(+), 15 deletions(-)
```

## Related Issues

Resolves the "Create New Paste" button not working on the view page.