### PR TITLE
chore: complete v1.0.3 version update and production config

### DIFF
--- a/client/delete.html
+++ b/client/delete.html
@@ -57,7 +57,7 @@
     </div>
 
     <!-- Version Display -->
-    <a href="https://github.com/SnarkyB/delerium-paste" target="_blank" rel="noopener noreferrer" class="version-display">v1.0.2</a>
+    <a href="https://github.com/SnarkyB/delerium-paste" target="_blank" rel="noopener noreferrer" class="version-display">v1.0.3</a>
     
     <script src="js/delete.js"></script>
   </body>

--- a/client/index.html
+++ b/client/index.html
@@ -717,7 +717,7 @@
     </div>
 
     <!-- Version Display -->
-    <a href="https://github.com/SnarkyB/delerium-paste" target="_blank" rel="noopener noreferrer" class="version-display">v1.0.2</a>
+    <a href="https://github.com/SnarkyB/delerium-paste" target="_blank" rel="noopener noreferrer" class="version-display">v1.0.3</a>
 
     <script type="module" src="js/app.js"></script>
   </body>

--- a/client/tests/e2e/delete-paste.spec.ts
+++ b/client/tests/e2e/delete-paste.spec.ts
@@ -396,7 +396,7 @@ test.describe('Delete Page - UI and UX', () => {
     // Verify version display
     const versionDisplay = page.locator('.version-display');
     await expect(versionDisplay).toBeVisible();
-    await expect(versionDisplay).toContainText('v1.0.2');
+    await expect(versionDisplay).toContainText('v1.0.3');
     
     // Verify it links to GitHub
     await expect(versionDisplay).toHaveAttribute('href', 'https://github.com/SnarkyB/delerium-paste');

--- a/client/view.html
+++ b/client/view.html
@@ -409,7 +409,7 @@
     </div>
 
     <!-- Version Display -->
-    <a href="https://github.com/SnarkyB/delerium-paste" target="_blank" rel="noopener noreferrer" class="version-display">v1.0.2</a>
+    <a href="https://github.com/SnarkyB/delerium-paste" target="_blank" rel="noopener noreferrer" class="version-display">v1.0.3</a>
 
     <script type="module" src="js/app.js"></script>
   </body>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,9 @@ services:
   server:
     build:
       context: ./server
+    restart: unless-stopped
     environment:
-      - DELETION_TOKEN_PEPPER=${DELETION_TOKEN_PEPPER:-change-me}
+      - DELETION_TOKEN_PEPPER=${DELETION_TOKEN_PEPPER}
     volumes:
       - server-data:/data
     expose:
@@ -14,17 +15,31 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
+    networks:
+      - app-network
+
   web:
     image: nginx:1.27-alpine
+    restart: unless-stopped
     depends_on:
       server:
         condition: service_healthy
     ports:
-      - "8080:80"
+      - "80:80"
+      - "443:443"
     volumes:
       - ./client:/usr/share/nginx/html:ro
       - ./reverse-proxy/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./reverse-proxy/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./ssl:/etc/nginx/ssl:ro
+      - ./logs/nginx:/var/log/nginx
+    networks:
+      - app-network
+
 volumes:
   server-data:
     driver: local
+
+networks:
+  app-network:
+    driver: bridge

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("org.owasp.dependencycheck") version "11.1.0"
 }
 
-version = "1.0.2"
+version = "1.0.3"
 
 repositories { mavenCentral() }
 dependencies {

--- a/server/docs/API.md
+++ b/server/docs/API.md
@@ -603,6 +603,6 @@ Error responses include a JSON body with an `error` field describing the issue.
 
 ## Version
 
-Current API version: **1.0.2**
+Current API version: **1.0.3**
 
 API versioning may be added in future releases if breaking changes are needed.


### PR DESCRIPTION
- Update server version to 1.0.3 in build.gradle.kts
- Update API documentation to reflect v1.0.3
- Update version display in all HTML files (index, view, delete)
- Update E2E test expectations for v1.0.3
- Restore production docker-compose.yml with SSL and networking
- Use local build instead of pre-built image for architecture compatibility